### PR TITLE
Minor edits 13032018

### DIFF
--- a/static/emails/csig-email-12.html
+++ b/static/emails/csig-email-12.html
@@ -44,7 +44,7 @@ li {
                           Dear C Moore,
                         </p>
                         <p style="border-left: 10px #dee0e2 solid; padding: 14px 0 14px 14px; font-size: 19px; line-height: 1.315789474; margin: 0 0 19px 0;">
-                            Reference: 1234567890 <br/>
+                            Reference: 7563589011 <br/>
 
                         <p>Her Majesty's Passport Office needs someone to confirm Susan Howard's identity for a new passport. Susan has given us your details.</p>
 

--- a/views/csig/user-contact/index.html
+++ b/views/csig/user-contact/index.html
@@ -22,10 +22,10 @@
               </ul>
 
             <span class="circle circle-step">2</span><h2>Contact the person</h2>
-            <p style="margin-left:32px;">You must contact the person before we send them an email with your details. You need to tell them:</p>
+            <p style="margin-left:32px;">You must contact the person before we send them an email with your details. You need to tell them your:</p>
             <ul class="list-bullet" style="margin-left:32px;">
-              <li>your date of birth, including the year</li>
-              <li>your current address</li>
+              <li>date of birth, including the year</li>
+              <li>current address</li>
               <!-- <li>any previous names</li> -->
             </ul>
 


### PR DESCRIPTION
- new reference in both places in email 12
- on ‘How to…’ screen put ‘your’ in the intro line instead of repeating
twice in bullets