### PR TITLE
Ts and Cs and 40 character limit

### DIFF
--- a/views/csig/referee/home-address-manual.html
+++ b/views/csig/referee/home-address-manual.html
@@ -15,7 +15,7 @@
     <label for="address-line-1" class="form-label-bold">
         Address<span class="visuallyhidden"> line 1</span>
 
-        <p class="form-hint" id="dob-hint">There is a limit of 40 characters in each line.</p>
+  
     </label>
     <input type="text" name="address-line-1" id="address-line-1" class="form-control form-control-3-4" aria-required="true"  maxlength="40"></div>
 

--- a/views/csig/referee/terms-and-conditions.html
+++ b/views/csig/referee/terms-and-conditions.html
@@ -14,8 +14,8 @@
 <p>You confirm that:</p>
 
 <ul class="list-bullet">
-    <li>the information you give is correct</li>
-    <li>you've known the applicant personally for at least 2 years, for example as a friend or neighbour</li>
+    <li>the information you'll give is correct</li>
+    <li>you've known the applicant personally for at least 2 years, for example as a friend, neighbour or colleague</li>
     <li>you work in or are retired from a <a href="https://www.gov.uk/countersigning-passport-applications/accepted-occupations-for-countersignatories">recognised profession</a></li>
     <li>you live in the UK and have a current UK passport</li>
 </ul>


### PR DESCRIPTION
- added ‘colleague’ to Terms and Conditions
- removed 40 limit help text from manual address entry