### PR TITLE
CSIG Content Tickets

### DIFF
--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -298,7 +298,7 @@
           "required": "Is this Susan Smith?"
         },
         "contact-csig": {
-          "required": "You need to contact the person"
+          "required": "You need to contact this person before we send them an email."
          },
         "application-country": {
           "required": "You must answer this question"

--- a/static/emails/csig-email-10.html
+++ b/static/emails/csig-email-10.html
@@ -41,7 +41,7 @@ li {
                         </h1>
 
                         <p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;">
-                          Dear D Smith,
+                          Dear David Smith,
                         </p>
                         <p style="border-left: 10px #dee0e2 solid; padding: 14px 0 14px 14px; font-size: 19px; line-height: 1.315789474; margin: 0 0 19px 0;">
                             Application reference: PEX 896 345 1083<br/>
@@ -51,9 +51,11 @@ li {
 
                         <h2>What you need to do</h2>
 
-                        <p>You need to remind Charlotte to go online and confirm your identity. We sent the details to cmoore123@gmail.com on 25 February 2018.</p>
+                        <p>You need to remind Charlotte Moore to go online and confirm your identity. We sent the details to cmoore123@gmail.com on 25 February 2018.</p>
 
-                        <p>If you want to ask someone else, sign into tracking <a href="/csig/user-renominate-anytime">https://www.passport.service.gov.uk/track</a></p>
+                        <p>If you need to, you can ask someone else. Sign in to enter their details: <a href="/csig/user-renominate-anytime">https://www.passport.service.gov.uk/track</a></p>
+
+                        <p>When you submit someone else's details, Charlotte will no longer be able to confirm your identity.</p>
 
                         Please don't reply to this email - it's an automatic message from an unmonitored account.
                         If you need help, <a href="https://www.passport.service.gov.uk/help">contact Her Majesty's Passport Office</a>.</p>

--- a/static/emails/csig-email-13.html
+++ b/static/emails/csig-email-13.html
@@ -41,7 +41,7 @@ li {
                         </h1>
 
                         <p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;">
-                          Dear S Howard,
+                          Dear Sue Howard,
                         </p>
                         <p style="border-left: 10px #dee0e2 solid; padding: 14px 0 14px 14px; font-size: 19px; line-height: 1.315789474; margin: 0 0 19px 0;">
                             Application reference: PEX 896 345 1083<br/>
@@ -51,9 +51,9 @@ li {
 
                         <h2>What you need to do</h2>
 
-                        <p>You need to ask someone to confirm your identity. They can do this online. They don't need to sign a printed photo.
+                        <p>You need to ask someone to confirm your identity. They will need to go online to do this. They don't need to sign a printed photo.
 
-                        <p>Sign into tracking to check who can do this and enter their name and email <a href="/csig/user">https://www.passport.service.gov.uk/track.</a></p>
+                        <p>Sign in to check who can do this and provide their details: <a href="/csig/user">https://www.passport.service.gov.uk/track.</a></p>
 
                         Please don't reply to this email - it's an automatic message from an unmonitored account.
                         If you need help, <a href="https://www.passport.service.gov.uk/help">contact Her Majesty's Passport Office</a>.</p>

--- a/static/emails/csig-email-14.html
+++ b/static/emails/csig-email-14.html
@@ -41,12 +41,12 @@ li {
                         </h1>
 
                         <p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;">
-                          Dear D Smith,
+                          Dear David Smith,
                         </p>
                         <p style="border-left: 10px #dee0e2 solid; padding: 14px 0 14px 14px; font-size: 19px; line-height: 1.315789474; margin: 0 0 19px 0;">
                             Application reference: PEX 896 345 1083<br/>
                         </p>
-                        <p>Charlotte has confirmed your identity. </p>
+                        <p>Charlotte Moore has confirmed your identity. </p>
 
                         <p>We'll continue with your application and let you know when your new passport is on it's way.</p>
 

--- a/static/emails/csig-email-15.html
+++ b/static/emails/csig-email-15.html
@@ -41,7 +41,7 @@ li {
                         </h1>
 
                         <p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;">
-                          Dear D Smith,
+                          Dear David Smith,
                         </p>
                         <p style="border-left: 10px #dee0e2 solid; padding: 14px 0 14px 14px; font-size: 19px; line-height: 1.315789474; margin: 0 0 19px 0;">
                             Application reference: PEX 896 345 1083<br/>
@@ -51,11 +51,11 @@ li {
 
                         <h2>What you need to do</h2>
 
-                        <p>You need to remind Charlotte to to go online and confirm your identity. We sent the details to cmoore123@gmail.com on 25 February 2018.</p>
+                        <p>You need to remind Charlotte Moore to to go online and confirm your identity. We sent the details to cmoore123@gmail.com on 25 February 2018.</p>
 
-                        <p>If Charlotte can't do this, you need to ask someone else.</p>
+                        <p>If Charlotte can't do this, you need to ask someone else. Sign in to enter their details: <a href="/csig/user-renominate-anytime">https://www.passport.service.gov.uk/track</a></p>
 
-                        <p>Sign into tracking to enter their name and email <a href="/csig/user-renominate-anytime">https://www.passport.service.gov.uk/track</a></p>
+                        <p>When you submit someone else's details, Charlotte will no longer be able to confirm your identity.</p>
 
 
                         Please don't reply to this email - it's an automatic message from an unmonitored account.

--- a/static/emails/csig-email-16.html
+++ b/static/emails/csig-email-16.html
@@ -41,7 +41,7 @@ li {
                         </h1>
 
                         <p style="font-size: 19px; line-height: 1.315789474; margin: 30px 0 30px 0;">
-                          Dear D Smith,
+                          Dear David Smith,
                         </p>
                         <p style="border-left: 10px #dee0e2 solid; padding: 14px 0 14px 14px; font-size: 19px; line-height: 1.315789474; margin: 0 0 19px 0;">
                             Application reference: PEX 896 345 1083<br/>
@@ -52,9 +52,11 @@ li {
 
                         <h2>What you need to do</h2>
 
-                        <p>We sent the details to cmoore123@gmail.com on 25 February 2018. If Charlotte can't go online and confirm your identity, you need to ask someone else.</p>
+                        <p>We sent the details to cmoore123@gmail.com on 25 February 2018.</p>
 
-                        <p>Sign into tracking to enter their name and email address <a href="/csig/user-renominate-anytime">https://www.passport.service.gov.uk/track</a></p>
+                        <p>If Charlotte Moore can't do this, you need to ask someone else. Sign in to enter their details: <a href="/csig/user-renominate-anytime">https://www.passport.service.gov.uk/track</a></p>
+
+                        <p>When you submit someone else's details, Charlotte will no longer be able to confirm your identity.</p>
 
                         Please don't reply to this email - it's an automatic message from an unmonitored account.
                         If you need help, <a href="https://www.passport.service.gov.uk/help">contact Her Majesty's Passport Office</a>.</p>

--- a/views/csig/referee-5/csig-invalid.html
+++ b/views/csig/referee-5/csig-invalid.html
@@ -10,14 +10,14 @@
 {{$content}}
 
 
-<p>You need to check:</p>
+<p>Please try again. You need to check:</p>
 
 <ul class="list-bullet">
   <li>the reference in the email from HM Passport Office</li>
   <li>the applicant's date of birth</li>
 </ul>
 
-<p>If this keeps happening, you need to tell the applicant to ask someone else.</p>
+<p>If this keeps happening, please let the applicant know. They'll need to contact the Passport Office.</p>
 
 <a class="button" href="applicant-info">Try again</a>
 

--- a/views/csig/user-renominate-anytime/renominate.html
+++ b/views/csig/user-renominate-anytime/renominate.html
@@ -13,8 +13,7 @@
           <li class="action_needed">
             <h2>Waiting for your identity to be confirmed</h2>
             <p class="time">25 February 2018 2:30pm</p>
-            <p>Email sent to {{values.csig-email}}<br>
-            You need to remind {{values.csig-name}} or <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
+            <p>Remind {{values.csig-name}} to go online and do this. We sent the details to {{values.csig-email}}. If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
           </li>
           <li>
             <h2>Ask someone to confirm your identity</h2>

--- a/views/csig/user/track-postcode.html
+++ b/views/csig/user/track-postcode.html
@@ -13,7 +13,7 @@
           <fieldset>
             <div id="address-postcode-group" class="form-group">
                 <label for="address-postcode" class="form-label-bold">
-                    Postcode
+                    Email
                 </label>
                 <input type="text" name="address-postcode" id="address-postcode" class="form-control input-code" aria-required="true">
             </div>


### PR DESCRIPTION
636 - remove online tracking as a noun
661 - action when details not recognised
664 - changed postcode label to email
665 - they need to go online
669 - original Csig can no longer do it (to email)
Plus:
- improved ‘you must contact this person’ validation message
- added applicants full first name to email salutations
- edits for consistency across emails