### PR TITLE
SAR and Someone else intro

### DIFF
--- a/views/12_15s/filter/apply-uk.html
+++ b/views/12_15s/filter/apply-uk.html
@@ -10,7 +10,7 @@
 
 {{$content}}
 
-  <p>If you're applying for a child, or an adult who does not have the mental or physical capacity to do this, select 'someone else'. </p>
+  <p>If you're applying for a child, or an adult without the mental or physical capacity to do this, select 'someone else'. </p>
 
 {{< hmpo-partials-form}}
     {{$form}}

--- a/views/12_15s/renew/sign.html
+++ b/views/12_15s/renew/sign.html
@@ -9,7 +9,7 @@
 {{$content}}
     {{< hmpo-partials-form}}
         {{$form}}
-            <p>The passport holder must sign their passport when they receive it. They won’t be able to use it until they do.</p>
+            <p>All passport holders aged 12 and older must sign their new passport when they receive it. They won’t be able to use it until they do.</p>
             {{#radio-group}}can-sign{{/radio-group}}
             <div id="no-sign" class="reveal js-hidden form-group">
               <div class="panel panel-border-narrow">


### PR DESCRIPTION
- added ‘passport holders aged 12 and older’ to SAR page
- crunched ‘who do not have the’ to ‘without’ on the Who is the
passport for intro copy