### PR TITLE
Email sent and waiting page

### DIFF
--- a/views/csig/user-contact/email-sent.html
+++ b/views/csig/user-contact/email-sent.html
@@ -9,7 +9,6 @@
           <h1>Email sent</h1>
           <p>Sent to <strong>{{values.csig-email}}</strong></p>
     </header>
-    <p>You’ll get an email when your identity has been confirmed.</p>
     {{#input-submit}}{{/input-submit}}
     {{/form}}
 {{/ hmpo-partials-form}}

--- a/views/csig/user-contact/tracking-waiting-renominate-anytime.html
+++ b/views/csig/user-contact/tracking-waiting-renominate-anytime.html
@@ -12,7 +12,7 @@
     </header>
     <h2>What happens next</h2>
     <p>If you don’t get an update in the next few days, remind the person confirming your identity.</p>
-    <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else to do this</a>.</p>
+    <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
     <hr>
     <h2>Application history</h2>
     <article>

--- a/views/csig/user-contact/tracking-waiting-renominate.html
+++ b/views/csig/user-contact/tracking-waiting-renominate.html
@@ -11,8 +11,10 @@
       Email sent to {{values.csig-email}}
     </header>
     <h2>What happens next</h2>
-    <p>If you don’t get an update in the next few days, remind the person confirming your identity.</p>
-    <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else to do this</a>.</p>
+
+    <p>When this is done, we'll update this page and send you an email. If you don't get an update in a few days, remind the person to go online and do this.</p>
+
+    <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
     <hr>
     <h2>Application history</h2>
     <article>

--- a/views/csig/user-contact/tracking-waiting.html
+++ b/views/csig/user-contact/tracking-waiting.html
@@ -11,7 +11,7 @@
     </header>
     <h2>What happens next</h2>
     <p>If you don’t get an update in the next few days, remind the person confirming your identity.</p>
-    <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else to do this</a>.</p>
+    <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
     <hr>
     <h2>Application history</h2>
     <article>

--- a/views/csig/user-renominate-anytime/renominate.html
+++ b/views/csig/user-renominate-anytime/renominate.html
@@ -13,7 +13,7 @@
   <p>We can't print your new passport until your identity is confirmed. You need to remind the person confirming your identity to go online and do it.</p>
   <input type="hidden" name="renominate" id="renominate" value="anytime">
 
-  <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else to do this</a>.</p>
+  <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
   <hr>
   <h2>Application history</h2>
   <article>

--- a/views/csig/user-renominate/renominate.html
+++ b/views/csig/user-renominate/renominate.html
@@ -8,8 +8,7 @@
   <header class="update-notice" style="background: #DEE0E2; color: #0B0C0C">
     <h1>Ask someone else to confirm <br> your identity</h1>
   </header>
-  <p>C Moore isn't eligible to do this for you. You need to ask someone else.</p>
-  <p>We can't print your new passport until your identity is confirmed.</p>
+  <p>Charlotte Moore can't do this for you &ndash; you need to ask someone else. We can't print your new passport until your identity is confirmed.</p>
   <input type="hidden" name="renominate" id="renominate" value="true">
   {{#input-submit}}{{/input-submit}}
   <hr>


### PR DESCRIPTION
- extra line removed from ‘Email sent’ page
- updated content on ‘What happens next’ section