### PR TITLE
Start page and someone else

### DIFF
--- a/views/ftas/filter/who-for.html
+++ b/views/ftas/filter/who-for.html
@@ -10,11 +10,16 @@
 
 {{$content}}
 
-  <!-- <p>If you're helping someone do this, they need to select 'Me'.</p> -->
-
 {{< hmpo-partials-form}}
     {{$form}}
         {{#radio-group}}application-for{{/radio-group}}
+
+        <div class="panel panel-border-narrow js-hidden" id="someone-else">
+          <label for="someone-else" class="form-label">
+          <p>You can apply for a child under 16 or an adult who doesn't have the mental or physical capacity to do this. If you're helping someone to do this, they need to select 'me'.</p>
+          </label>
+      </div>
+
         {{#input-submit}}{{/input-submit}}
     {{/form}}
 {{/ hmpo-partials-form}}

--- a/views/ftas/startpage/index.html
+++ b/views/ftas/startpage/index.html
@@ -14,9 +14,12 @@
 
 <ul class="list-bullet">
     <li>renew an adult or child passport</li>
-    <li>apply for a first passport</li>
+    <li>apply for a first adult or child passport</li>
     <li>replace a lost, stolen or damaged passport</li>
     <li>get a new passport if you've changed your name or details</li>
+</ul>
+
+<p>You can make an application on behalf of someone else.</p>
 </ul>
 
 <p id="get-started" class="get-started group">


### PR DESCRIPTION
- added ‘apply for a first or adult passport’ and ‘You can make an
application on behalf of someone else’ to start page
- added reveal content under ‘someone else’ selection