### PR TITLE
FTA content updates

### DIFF
--- a/locales/en/default.json
+++ b/locales/en/default.json
@@ -109,7 +109,7 @@
         },
         "previous-name": {
             "legend": "Have you ever been known by any other names?",
-            "hint": "For example a maiden name, names from previous marriages or a different name at birth."
+            "hint": "For example, a name from previous marriage or civil partnership."
         },
         "previous-name-change": {
             "legend": "Have you ever been known by any other names?"

--- a/views/ftas/filter/dual-national.html
+++ b/views/ftas/filter/dual-national.html
@@ -17,7 +17,7 @@
 
 <div id="same-name" class="reveal js-hidden">
   <div class="panel panel-border-narrow">
-    <p>They must be in the same name that you want in your UK passport. If they aren't, you must update them
+    <p>They should be in the same name that you want in your UK passport. If they aren't, you may need to update them
       before you apply.</p>
   </div>
 </div>

--- a/views/ftas/filter/first-uk.html
+++ b/views/ftas/filter/first-uk.html
@@ -18,7 +18,7 @@
 
         <div id="passport-before-no" class="reveal js-hidden">
             <div class="panel panel-border-narrow">
-                <p>You may need to have an <a href="../../guidance/identity-interviews" target="_blank">identity interview</a>. We'll tell you if that happens and what you need to do.</p>
+                <p>You may need to have a <a href="../../guidance/identity-interviews" target="_blank">passport interview</a>. We'll tell you if that happens and what you need to do.</p>
             </div>
         </div>
 

--- a/views/ftas/filter/passport-damaged.html
+++ b/views/ftas/filter/passport-damaged.html
@@ -14,7 +14,7 @@
       <fieldset class="inline">
           {{#radio-group}}passport-damaged{{/radio-group}}
           <details>
-              <summary><span class="summary">What kind of damage matters?</span></summary>
+              <summary><span class="summary">What kind of damage matters</span></summary>
               <div class="panel panel-border-narrow">
                 <p>Her Majesty's Passport Office classes a passport as damaged if:</p>
                 <ul class="list-bullet">

--- a/views/ftas/intro/index.html
+++ b/views/ftas/intro/index.html
@@ -17,7 +17,8 @@
                     <li>
                         <span class="circle circle-step">1</span>
                         <h2>Get a digital passport photo</h2>
-                        <p style="margin-left:32px;">We'll show you how to get a good passport photo.</p>
+                        <p style="margin-left:32px;">We'll show you how to get a digital photo that <a href="/how-to">meets the rules</a>.</p>
+
                     </li>
                     <li>
                         <span class="circle circle-step">2</span>
@@ -38,7 +39,7 @@
                     <li>
                         <span class="circle circle-step">5</span>
                         <h2>Go for an interview</h2>
-                        <p style="margin-left:32px;">If you need an <a href="../../guidance/identity-interviews" target="_blank">identity interview</a>, we'll write to you. The letter will tell you what you need to do.</p>
+                        <p style="margin-left:32px;">If you need a <a href="../../guidance/identity-interviews" target="_blank">passport interview</a>, we'll write to you. The letter will tell you what you need to do.</p>
                     </li>
                 </ul>
                 <br>

--- a/views/guidance/identity-interviews.html
+++ b/views/guidance/identity-interviews.html
@@ -1,18 +1,22 @@
 {{< layout}}
 
-{{$pageTitle}}Identity interviews{{/pageTitle}}
+{{$pageTitle}}Passport interviews{{/pageTitle}}
 
 {{$propositionHeader}}{{/propositionHeader}}
 
 {{$header}}
-    <h1>Identity interviews</h1>
+    <h1>Passport interviews</h1>
 {{/header}}
 
 {{$content}}
 
-<p>You may be asked for an interview at a <a href="https://www.gov.uk/passport-interview-office" target="_blank">passport office</a> if you've never had a UK passport before, or you're renewing an old style passport with a dark blue cover.</p>
+<p>You may be asked for an interview at a <a href="https://www.gov.uk/passport-interview-office" target="_blank">passport office</a> if you've never had a UK passport before, or you're renewing an old style passport.</p>
 
-<p>The interview will help us confirm your identity and that the passport application belongs to you.</p>
+<p>The interview helps us confirm who you are and that the passport application belongs to you.</p>
+
+<p>It's an important part of protecting your identity. It stops other people applying for a passport in your name.</p>
+
+
 
 
 <br>
@@ -21,22 +25,34 @@
 
 <p>Your appointment will last about 30 minutes.</p>
 
-<p>We'll ask you some simple questions that someone trying to steal your identity may not know. We'll also check your photo looks like you.</p>
+<p>We'll ask you some questions about yourself that someone trying to steal your identity may not know. We'll also check your photo looks like you.</p>
 
-<p>You can bring a friend or relative with you to the office, but they'll have to wait in reception while you have your interview.</p>
+<p>You can bring a friend or relative with you to the office, but they can't sit with you during the interview.</p>
+
+<div class="panel panel-border-wide">
+  <p>You won't get your new passport on the day. We'll carry out final checks on your application before we send your new passport.</p>
+</div>
+
 <br>
 
 <h2>Booking your appointment</h2>
-<p>We'll send you a letter asking you to phone for an appointment. When you call, tell us if you need a:</p>
+<p>We'll send you a letter asking you to phone for an appointment. When you call, tell us if you need:</p>
 
 <ul class="list-bullet">
-    <li>sign language interpreter</li>
-    <li>private interview room because you don't want to uncover your face in public</li>
+    <li>a sign language interpreter</li>
+    <li>someone to be with you during the interview, such as a parent or carer
+    <li>a private interview room because you don't want to uncover your face in public</li>
 </ul>
 <br>
 
-<h2>After the interview</h2>
-<p>You won't get your new passport on the day. We'll carry out final checks on your application before we send your new passport.</p>
+<h2>If you have a disability and can't attend</h2>
+
+<p>You'll need to send a letter from your doctor if you have a mental or physical disability that would prevent you from taking part in a passport interview.</p>
+
+<p>Include the letter with your documents. We'll tell you where to send them after we've received your application.</p>
+
+<br>
+
 
 {{/content}}
 


### PR DESCRIPTION
Content amends including:
- DCSRD 181 change to dual national reveal
- amend 'passport interview' and reference in how to apply page and add photo link in first bullet
- amend hint text on previous names
- amend reveal for damaged ppt question
- DCSRD 175 update passport interview guidance