### PR TITLE
Payment reference and Applicant's details

### DIFF
--- a/views/ftas/intro/what-you-need.html
+++ b/views/ftas/intro/what-you-need.html
@@ -13,7 +13,7 @@
 
 <p style="margin-bottom: 30px;">You won't be able to save your application – get this information ready before you continue. If you can't provide these details, you'll need to tell us why.</p>
 
-<h2>Your details</h2>
+<h2>Applicant's details</h2>
 <ul class="list-bullet list-bullet-header-spacing">
     {{#values.naturalisation-registration-certificate}}<li>naturalisation or registration certificate</li>{{/values.naturalisation-registration-certificate}}
     {{^values.naturalisation-registration-certificate}}<li>birth or adoption certificate</li>{{/values.naturalisation-registration-certificate}}

--- a/views/ftas/renew/confirmation.html
+++ b/views/ftas/renew/confirmation.html
@@ -10,8 +10,9 @@
 <header class="update-notice update-notice--grey">
     <h1><span class="icon-tick"></span> Payment successful</h1>
 
-        <p>You've paid £75.50, reference IE19852</br>
-Email confirmation sent to <strong>c.moore@test-corp.co.uk</strong></p>
+        <p>£75.50<br>
+        Payment reference IE19852</br>
+        Email confirmation sent to <strong>c.moore@test-corp.co.uk</strong></p>
     <a style="color: #0b0c0c" href="#">Download PDF receipt</a>
 </header>
 


### PR DESCRIPTION
- added ‘Payment’ to payment receipt and separated on to a new line
- On What you’ll need, changed ‘Your details’ to ‘Applicant’s details’