### PR TITLE
- generic content on passport options page

### DIFF
--- a/routes/ftas/renew/fields.js
+++ b/routes/ftas/renew/fields.js
@@ -1232,11 +1232,11 @@ module.exports = {
         },
         options: [{
                 value: '34',
-                label: 'Standard adult 34-page passport (£75.50)'
+                label: 'Standard 34-page passport (£75.50)'
             },
             {
                 value: '50',
-                label: 'Jumbo adult 50-page passport (£85.50)'
+                label: 'Jumbo 50-page passport (£85.50)'
             }
         ],
         validate: [

--- a/views/12_15s/renew/signing-you-passport.html
+++ b/views/12_15s/renew/signing-you-passport.html
@@ -3,7 +3,7 @@
 {{$pageTitle}}Signing your passport{{/pageTitle}}
 
 {{$header}}
-    <h1>Signing your new passport</h1>
+    <h1>Signing a new passport</h1>
 {{/header}}
 
 {{$content}}

--- a/views/address/renew/sign.html
+++ b/views/address/renew/sign.html
@@ -1,6 +1,6 @@
 {{< layout}}
 
-{{$pageTitle}}Signing your new passport{{/pageTitle}}
+{{$pageTitle}}Signing a new passport{{/pageTitle}}
 
 {{$header}}
     <h1>Signing a new passport</h1>

--- a/views/ftas/filter/who-for.html
+++ b/views/ftas/filter/who-for.html
@@ -18,8 +18,8 @@
           <label for="someone-else" class="form-label">
         <p>You can only apply for someone else if you're legally responsible for them, for example:</p>
           <ul class="list-bullet">
-            <li>a child under 16</li>
             <li>an adult who doesn't have mental or physical capacity</li>
+            <li>a child under 16</li>
           </ul>
           </label>
         </div>

--- a/views/ftas/renew/signing-you-passport.html
+++ b/views/ftas/renew/signing-you-passport.html
@@ -3,7 +3,7 @@
 {{$pageTitle}}Signing your passport{{/pageTitle}}
 
 {{$header}}
-    <h1>Signing your new passport</h1>
+    <h1>Signing a new passport</h1>
 {{/header}}
 
 {{$content}}

--- a/views/priority-service/renew/sign.html
+++ b/views/priority-service/renew/sign.html
@@ -1,9 +1,9 @@
 {{< layout}}
 
-{{$pageTitle}}Signing your new passport{{/pageTitle}}
+{{$pageTitle}}Signing a new passport{{/pageTitle}}
 
 {{$header}}
-    <h1>Signing your new passport</h1>
+    <h1>Signing a new passport</h1>
 {{/header}}
 
 {{$content}}

--- a/views/priority-service/renew/signing-you-passport.html
+++ b/views/priority-service/renew/signing-you-passport.html
@@ -1,9 +1,9 @@
 {{< layout}}
 
-{{$pageTitle}}Signing your passport{{/pageTitle}}
+{{$pageTitle}}Signing a passport{{/pageTitle}}
 
 {{$header}}
-    <h1>Signing your new passport</h1>
+    <h1>Signing a new passport</h1>
 {{/header}}
 
 {{$content}}

--- a/views/production/renew/sign.html
+++ b/views/production/renew/sign.html
@@ -1,9 +1,9 @@
 {{< layout}}
 
-{{$pageTitle}}Signing your new passport{{/pageTitle}}
+{{$pageTitle}}Signing a new passport{{/pageTitle}}
 
 {{$header}}
-    <h1>Signing your new passport</h1>
+    <h1>Signing a new passport</h1>
 {{/header}}
 
 {{$content}}

--- a/views/production/renew/signing-you-passport.html
+++ b/views/production/renew/signing-you-passport.html
@@ -1,9 +1,9 @@
 {{< layout}}
 
-{{$pageTitle}}Signing your passport{{/pageTitle}}
+{{$pageTitle}}Signing a passport{{/pageTitle}}
 
 {{$header}}
-    <h1>Signing your new passport</h1>
+    <h1>Signing a new passport</h1>
 {{/header}}
 
 {{$content}}


### PR DESCRIPTION
- generic H1 in ‘Signing a new passport’
- swapped order of examples on someone else reveal