### PR TITLE
Someone else and can't print passport messaging

### DIFF
--- a/static/emails/csig-email-9.html
+++ b/static/emails/csig-email-9.html
@@ -47,7 +47,7 @@ li {
                             Application reference: PEX 896 345 1083<br/>
                         </p>
 
-                        <p>Your passport application is on hold because your old passport is damaged. We can't print your new passport until your identity is confirmed.</p>
+                        <p>Your passport application is on hold because your old passport is damaged. We can't start work on your application until your identity is confirmed.</p>
 
                         <h2>What you need to do</h2>
 

--- a/static/emails/csig-texts.html
+++ b/static/emails/csig-texts.html
@@ -78,7 +78,7 @@ li {
                       <h3>Ask someone</h3>
                       <h4>Reminder 1</h4>
 
-                      We can't print your new passport until your identity is confirmed. </p>
+                      We can't start work on your application until your identity is confirmed. </p>
 
                       Sign in to check who can do this and provide their details:</br>
                       https://www.passport.service.gov.uk/track (application reference PEX{{reference}})
@@ -102,7 +102,7 @@ li {
                       <h3>Remind the person</h3>
                       <h4>Reminder 1</h4>
 
-                      We can't print your new passport until your identity is confirmed. Remind Charlotte Moore to go online to do this.</p>
+                      We can't start work on your application until your identity is confirmed. Remind Charlotte Moore to go online to do this.</p>
 
                       Track your application:<br>
                       https://www.passport.service.gov.uk/track (application reference PEX{{reference}})

--- a/views/csig/track/tracking-waiting-renominate-anytime.html
+++ b/views/csig/track/tracking-waiting-renominate-anytime.html
@@ -11,8 +11,8 @@
       Email sent to {{values.csig-email}}
     </header>
     <h2>What happens next</h2>
-    <p>If you don’t get an update in the next few days, remind the person doing this for you.</p>
-    <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
+    <p>If you don’t get an update in the next few days, remind the person doing this for you or  <a href="/csig/user-contact/" id="someone-else">ask someone else</a>. You can only ask one person at a time.</p>
+
     <hr>
     <h2>Application history</h2>
     <article>

--- a/views/csig/track/tracking-waiting-renominate.html
+++ b/views/csig/track/tracking-waiting-renominate.html
@@ -12,9 +12,10 @@
     </header>
     <h2>What happens next</h2>
 
-    <p>When this is done, we'll update this page and send you an email. If you don't get an update in a few days, remind the person to go online and do this.</p>
+    <p>When this is done, we'll update this page and send you an email.</p>
 
-    <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
+    <p>If you don’t get an update in the next few days, remind the person doing this for you or  <a href="/csig/user-contact/" id="someone-else">ask someone else</a>. You can only ask one person at a time.</p>
+
     <hr>
     <h2>Application history</h2>
     <article>

--- a/views/csig/track/tracking-waiting.html
+++ b/views/csig/track/tracking-waiting.html
@@ -10,8 +10,7 @@
       Email sent to {{values.csig-email}}
     </header>
     <h2>What happens next</h2>
-    <p>If you don’t get an update in the next few days, remind the person doing this for you.</p>
-    <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
+    <p>If you don’t get an update in the next few days, remind the person doing this for you or  <a href="/csig/user-contact/" id="someone-else">ask someone else</a>. You can only ask one person at a time.</p>
     <hr>
     <h2>Application history</h2>
     <article>

--- a/views/csig/user-contact/tracking-waiting-renominate-anytime.html
+++ b/views/csig/user-contact/tracking-waiting-renominate-anytime.html
@@ -11,8 +11,8 @@
       Email sent to {{values.csig-email}}
     </header>
     <h2>What happens next</h2>
-    <p>If you don’t get an update in the next few days, remind the person doing this for you.</p>
-    <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
+    <p>If you don’t get an update in the next few days, remind the person doing this for you or  <a href="/csig/user-contact/" id="someone-else">ask someone else</a>. You can only ask one person at a time.</p>
+
     <hr>
     <h2>Application history</h2>
     <article>

--- a/views/csig/user-contact/tracking-waiting-renominate.html
+++ b/views/csig/user-contact/tracking-waiting-renominate.html
@@ -12,9 +12,9 @@
     </header>
     <h2>What happens next</h2>
 
-    <p>When this is done, we'll update this page and send you an email. If you don't get an update in a few days, remind the person to go online and do this.</p>
+    <p>When this is done, we'll update this page and send you an email.</p>
+    <p>If you don’t get an update in the next few days, remind the person doing this for you or  <a href="/csig/user-contact/" id="someone-else">ask someone else</a>. You can only ask one person at a time.</p>
 
-    <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
     <hr>
     <h2>Application history</h2>
     <article>

--- a/views/csig/user-contact/tracking-waiting.html
+++ b/views/csig/user-contact/tracking-waiting.html
@@ -10,8 +10,7 @@
         <p>Email sent to {{values.csig-email}}</p>
       </header>
       <h2>What happens next</h2>
-      <p>If you don’t get an update in the next few days, remind the person doing this for you.</p>
-      <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
+      <p>If you don’t get an update in the next few days, remind the person doing this for you or  <a href="/csig/user-contact/" id="someone-else">ask someone else</a>. You can only ask one person at a time.</p>
       <hr>
       <h2>Application history</h2>
       <article>

--- a/views/csig/user-renominate-anytime/need-csig.html
+++ b/views/csig/user-renominate-anytime/need-csig.html
@@ -6,7 +6,7 @@
   <header class="update-notice" style="background: #DEE0E2; color: #0B0C0C">
     <h1>You need to ask someone to<br>confirm your identity</h1>
   </header>
-  <p>Your old passport is damaged. We can't print your new passport until your identity is confirmed.</p>
+  <p>Your old passport is damaged. We can't start work on your application until your identity is confirmed.</p>
 
   <a href="../csig" class="button">Continue</a>
   <br><br>

--- a/views/csig/user-renominate-anytime/renominate.html
+++ b/views/csig/user-renominate-anytime/renominate.html
@@ -10,10 +10,11 @@
     Email sent to test@thundercats.com
   </header>
 
-  <p>We can't print your new passport until your identity is confirmed. You need to remind the person confirming your identity to go online and do it.</p>
-  <input type="hidden" name="renominate" id="renominate" value="anytime">
+  <p>We can't start work on your application until your identity is confirmed.</p>
 
-  <p>If you need to, you can <a href="/csig/user-contact/" id="someone-else">ask someone else</a>.</p>
+  <p>If you don’t get an update in the next few days, remind the person doing this for you or  <a href="/csig/user-contact/" id="someone-else">ask someone else</a>. You can only ask one person at a time.</p>
+
+  <input type="hidden" name="renominate" id="renominate" value="anytime">
   <hr>
   <h2>Application history</h2>
   <article>

--- a/views/csig/user-renominate/need-csig.html
+++ b/views/csig/user-renominate/need-csig.html
@@ -6,7 +6,7 @@
   <header class="update-notice" style="background: #DEE0E2; color: #0B0C0C">
     <h1>You need to ask someone to<br>confirm your identity</h1>
   </header>
-  <p>Your old passport is damaged. We can't print your new passport until your identity is confirmed.</p>
+  <p>Your old passport is damaged. We can't start work on your application until your identity is confirmed.</p>
 
   <a href="../csig" class="button">Continue</a>
   <br><br>

--- a/views/csig/user-renominate/renominate.html
+++ b/views/csig/user-renominate/renominate.html
@@ -8,7 +8,7 @@
       <header class="update-notice update-notice--grey">
         <h1>Ask someone else to confirm <br> your identity</h1>
       </header>
-      <p>Charlotte Moore can't do this for you &ndash; you need to ask someone else. We can't print your new passport until your identity is confirmed.</p>
+      <p>Charlotte Moore can't do this for you &ndash; you need to ask someone else. We can't start work on your application until your identity is confirmed.</p>
       <input type="hidden" name="renominate" id="renominate" value="true">
       {{#input-submit}}{{/input-submit}}
       <hr>

--- a/views/csig/user-send-book/need-csig.html
+++ b/views/csig/user-send-book/need-csig.html
@@ -6,7 +6,7 @@
   <header class="update-notice" style="background: #DEE0E2; color: #0B0C0C">
     <h1>You need to ask someone to<br>confirm your identity</h1>
   </header>
-  <p>Your old passport is damaged. We can't print your new passport until your identity is confirmed.</p>
+  <p>Your old passport is damaged. We can't start work on your application until your identity is confirmed.</p>
 
   <a href="../csig" class="button">Continue</a>
   <br><br>


### PR DESCRIPTION
- made the ‘someone else’ link less attractive
- added ‘You can only ask one person at a time’ message
- changed ‘We can’t print your new passport until your identity is
confirmed’ to ‘We can’t start work on your application until your
identity is confirmed.’