### PR TITLE
Add in logic to go back to CSIG

### DIFF
--- a/routes/ftas/renew/steps.js
+++ b/routes/ftas/renew/steps.js
@@ -388,7 +388,20 @@ module.exports = {
     },
     '/docs-renew': {
         backLink: 'summary',
-        next: '/declaration'
+        next: '/declaration',
+        forks: [{
+                target: '../../../csig/user/need-csig',
+                condition: function (req, res) {
+                    return req.session['hmpo-wizard-common']['routeFromCsig'] == true;
+                }
+            },
+            {
+                target: '../../../csig/user-contact/tracking-waiting',
+                condition: function (req, res) {
+                    return req.session['hmpo-wizard-common']['trackWaiting'] == true;
+                }
+            }
+        ]
     },
     '/docs-fta-thirdparty': {
         backLink: 'summary',

--- a/views/ftas/renew/docs-fta.html
+++ b/views/ftas/renew/docs-fta.html
@@ -34,11 +34,7 @@
 
     {{< hmpo-partials-form}}
         {{$form}}
-            {{#nunjucks}}
-                    <div class="form-group">
-                        <input type="submit" value="Continue" class="button">
-                    </div>
-            {{/nunjucks}}
+            {{#input-submit}}{{/input-submit}}
         {{/form}}
     {{/ hmpo-partials-form}}
 

--- a/views/ftas/renew/docs-renew.html
+++ b/views/ftas/renew/docs-renew.html
@@ -34,19 +34,7 @@
 
     {{< hmpo-partials-form}}
         {{$form}}
-            {{#nunjucks}}
-                {% if values['routeFromCsig'] === true %}
-                    <div class="form-group">
-                        {# <input type="button" value="Continue" class="button" onclick="javascript:history.back()"> #}
-                        <input type="submit" value="Continue" class="button"> {# FIXME: TEMP FIX. Need to fix properly. #}
-                    </div>
-
-                {% else %}
-                    <div class="form-group">
-                        <input type="submit" value="Continue" class="button">
-                    </div>
-                {% endif %}
-            {{/nunjucks}}
+            {{#input-submit}}{{/input-submit}}
         {{/form}}
     {{/ hmpo-partials-form}}
 


### PR DESCRIPTION
- Reuse logic from `/docs-fta` for `/docs-renew`
- Small refactor to use `input-submit` button