### PR TITLE
HM Passport Office change to align with logo

### DIFF
--- a/static/emails/csig/csig-170731/csig-email-1.html
+++ b/static/emails/csig/csig-170731/csig-email-1.html
@@ -60,7 +60,7 @@ li {
                         <h2>When you need to do this</h2>
                         <p>You need to do this before 14 September 2017 or the person applying will need to start a new application.</p>
 
-                        <p>If you don’t meet the criteria or you have any questions, <a href="https://www.passport.service.gov.uk/help">contact Her Majesty's Passport Office</a>.</p>
+                        <p>If you don’t meet the criteria or you have any questions, <a href="https://www.passport.service.gov.uk/help">contact HM Passport Office</a>.</p>
 
                         <p>Please don't reply to this email - it's an automatic message from an unmonitored account.</p>
 

--- a/static/emails/csig/csig-170731/csig-email-5.html
+++ b/static/emails/csig/csig-170731/csig-email-5.html
@@ -73,7 +73,7 @@ li {
                         <p>You can track your application at:<br>
                         <a href="https://www.passport.service.gov.uk/track">https://www.passport.service.gov.uk/track</a></p>
 
-                        <p>For other queries, you can <a href="https://www.passport.service.gov.uk/help">contact Her Majesty's Passport Office</a>.</p>
+                        <p>For other queries, you can <a href="https://www.passport.service.gov.uk/help">contact HM Passport Office</a>.</p>
 
                         <p>Please don't reply to this email - it's an automatic message from an unmonitored account.</p>
 

--- a/static/emails/csig/csig-email-1.html
+++ b/static/emails/csig/csig-email-1.html
@@ -60,7 +60,7 @@ li {
                         <h2>When you need to do this</h2>
                         <p>You need to do this before 14 September 2017 or the person applying will need to start a new application.</p>
 
-                        <p>If you don’t meet the criteria or you have any questions, <a href="https://www.passport.service.gov.uk/help">contact Her Majesty's Passport Office</a>.</p>
+                        <p>If you don’t meet the criteria or you have any questions, <a href="https://www.passport.service.gov.uk/help">contact HM Passport Office</a>.</p>
 
                         <p>Please don't reply to this email - it's an automatic message from an unmonitored account.</p>
 

--- a/static/emails/csig/csig-email-5.html
+++ b/static/emails/csig/csig-email-5.html
@@ -72,7 +72,7 @@ li {
                         <p></p>
 
                         <p>Please don't reply to this email - it's an automatic message from an unmonitored account.</p>
-                        <p>If you need help, <a href="https://www.passport.service.gov.uk/help">contact Her Majesty's Passport Office</a>.</p>
+                        <p>If you need help, <a href="https://www.passport.service.gov.uk/help">contact HM Passport Office</a>.</p>
 
                     </td>
 

--- a/static/emails/csig/csig-email-6.html
+++ b/static/emails/csig/csig-email-6.html
@@ -69,7 +69,7 @@ li {
                           <p>Go to <a href="/csig_170830/referee-5">http://gov.uk/confirm-identity/3w12aq7</a></p>
 
                         <p>Please don't reply to this email - it's an automatic message from an unmonitored account.</p>
-                        <p>If you've received this email by mistake or you need help, <a href="https://www.passport.service.gov.uk/help">contact Her Majesty's Passport Office</a>.</p>
+                        <p>If you've received this email by mistake or you need help, <a href="https://www.passport.service.gov.uk/help">contact HM Passport Office</a>.</p>
 
                     </td>
 

--- a/static/emails/csig/csig-email-7.html
+++ b/static/emails/csig/csig-email-7.html
@@ -58,7 +58,7 @@ li {
                         <p>Sign into your tracking page to find out who can do this and what they'll need: <a href="/csig_170830/user">https://www.passport.service.gov.uk/track.</a></p>
 
                         <p>Please don't reply to this email - it's an automatic message from an unmonitored account.</p>
-                        <p>If you need help, <a href="https://www.passport.service.gov.uk/help">contact Her Majesty's Passport Office</a>.</p>
+                        <p>If you need help, <a href="https://www.passport.service.gov.uk/help">contact HM Passport Office</a>.</p>
 
                     </td>
                 </tr>

--- a/static/emails/csig/csig-email-8.html
+++ b/static/emails/csig/csig-email-8.html
@@ -71,7 +71,7 @@ li {
                           <p>Go to <a href="/csig_170830/referee-5">http://gov.uk/confirm-identity/3w12aq7</a></p>
 
                           Please don't reply to this email - it's an automatic message from an unmonitored account.
-                          If you need help, <a href="https://www.passport.service.gov.uk/help">contact Her Majesty's Passport Office</a>.</p>
+                          If you need help, <a href="https://www.passport.service.gov.uk/help">contact HM Passport Office</a>.</p>
 
                     </td>
 

--- a/static/emails/csig/csig-email-9.html
+++ b/static/emails/csig/csig-email-9.html
@@ -56,7 +56,7 @@ li {
                         <p>Sign into your tracking page to check who can do this and what they need: <a href="/csig_170830/user">https://www.passport.service.gov.uk/track.</a></p>
 
                         Please don't reply to this email - it's an automatic message from an unmonitored account.
-                        If you need help, contact <a href="https://www.passport.service.gov.uk/help"> Her Majesty's Passport Office</a>.</p>
+                        If you need help, contact <a href="https://www.passport.service.gov.uk/help"> HM Passport Office</a>.</p>
 
                     </td>
                 </tr>

--- a/views/12_15s/filter/passport-damaged.html
+++ b/views/12_15s/filter/passport-damaged.html
@@ -16,7 +16,7 @@
           <details>
               <summary><span class="summary">What kind of damage matters?</span></summary>
               <div class="panel panel-border-narrow">
-                <p>Her Majesty's Passport Office classes a passport as damaged if:</p>
+                <p>HM Passport Office classes a passport as damaged if:</p>
                 <ul class="list-bullet">
                   <li>you can't read any of the details</li>
                   <li>the laminate cover has come away</li>

--- a/views/12_15s/overseas/passport-damaged.html
+++ b/views/12_15s/overseas/passport-damaged.html
@@ -16,7 +16,7 @@
           <details>
               <summary><span class="summary">I'm not sure if my passport is damaged</span></summary>
               <div class="panel panel-border-narrow">
-                <p>Her Majesty's Passport Office classes your passport as damaged if:</p>
+                <p>HM Passport Office classes your passport as damaged if:</p>
                 <ul class="list-bullet">
                   <li>you can't read any of your details</li>
                   <li>the laminate cover has come away</li>

--- a/views/address/filter/passport-damaged.html
+++ b/views/address/filter/passport-damaged.html
@@ -16,7 +16,7 @@
           <details>
               <summary><span class="summary">I'm not sure if their passport is damaged</span></summary>
               <div class="panel panel-border-narrow">
-                <p>Her Majesty's Passport Office classes a passport as damaged if:</p>
+                <p>HM Passport Office classes a passport as damaged if:</p>
                 <ul class="list-bullet">
                   <li>you can't read any of the details</li>
                   <li>the laminate cover has come away</li>

--- a/views/address/overseas/passport-damaged.html
+++ b/views/address/overseas/passport-damaged.html
@@ -16,7 +16,7 @@
           <details>
               <summary><span class="summary">I'm not sure if my passport is damaged</span></summary>
               <div class="panel panel-border-narrow">
-                <p>Her Majesty's Passport Office classes your passport as damaged if:</p>
+                <p>HM Passport Office classes your passport as damaged if:</p>
                 <ul class="list-bullet">
                   <li>you can't read any of your details</li>
                   <li>the laminate cover has come away</li>

--- a/views/csig/referee-5/declaration.html
+++ b/views/csig/referee-5/declaration.html
@@ -12,7 +12,7 @@
 
 <ul class="list-bullet">
     <li>the information you'll give is correct</li>
-    <li>Her Majesty's Passport Office and Experian can check the information
+    <li>HM Passport Office and Experian can check the information
     <li>you agree to the <a href="/csig/referee/terms-and-conditions" target="_blank">terms and conditions<span class="visuallyhidden"></span></a></li>
 </ul>
     <div class="panel-important" style="margin-bottom: 10px">

--- a/views/csig/referee/terms-and-conditions.html
+++ b/views/csig/referee/terms-and-conditions.html
@@ -25,7 +25,7 @@
     <li>related to the applicant by birth or marriage</li>
     <li>in a personal relationship with the applicant</li>
     <li>living at the same address as the applicant</li>
-    <li>employed by Her Majesty's Passport Office</li>
+    <li>employed by HM Passport Office</li>
 </ul>
 
 <p>HM Passport Office may contact you to check any of the details you provide.</p>

--- a/views/ftas/overseas/passport-damaged.html
+++ b/views/ftas/overseas/passport-damaged.html
@@ -16,7 +16,7 @@
           <details>
               <summary><span class="summary">I'm not sure if my passport is damaged</span></summary>
               <div class="panel panel-border-narrow">
-                <p>Her Majesty's Passport Office classes your passport as damaged if:</p>
+                <p>HM Passport Office classes your passport as damaged if:</p>
                 <ul class="list-bullet">
                   <li>you can't read any of your details</li>
                   <li>the laminate cover has come away</li>

--- a/views/govuk/how-confirm.html
+++ b/views/govuk/how-confirm.html
@@ -31,7 +31,7 @@
 
 
 <div class="govuk-govspeak direction-ltr rich-govspeak disable-youtube">
-<p>You&lsquo;ll receive an email from Her Majesty's Passport Office with an application reference and a link to go online. You&lsquo;ll be shown a photo of the person applying and asked a few questions about how you know them.</p>
+<p>You&lsquo;ll receive an email from HM Passport Office with an application reference and a link to go online. You&lsquo;ll be shown a photo of the person applying and asked a few questions about how you know them.</p>
 <p>You need to know the applicant&lsquo;s date of birth, including the year.</p>
 <p>To confirm who you are and your profession, you&lsquo;ll need to enter your:
   <ul>

--- a/views/govuk/terms.html
+++ b/views/govuk/terms.html
@@ -18,7 +18,7 @@
 <li>aren’t breaking the terms of a court order by making this application</li>
 <li>don’t owe any money to the UK government for repatriation costs, for example when the government pays to get you home from abroad</li>
 <li>understand by voluntarily applying for a UK passport you may lose citizenship of another country</li>
-<li>will tell Her Majesty's Passport Office if you were born through surrogacy</li>
+<li>will tell HM Passport Office if you were born through surrogacy</li>
 </ul>
 <p>
 <p>If this is an application for a child passport, you confirm that you:</p>

--- a/views/govuk/who-can-do-this.html
+++ b/views/govuk/who-can-do-this.html
@@ -30,7 +30,7 @@
 
 
 <div class="govuk-govspeak direction-ltr rich-govspeak disable-youtube">
-<p>When a person applies for a UK passport, Her Majesty's Passport Office sometimes needs to check that they are who they claim to be. <br><br>The person applying for the passport must ask someone they know well to confirm their identity.</p><p><span style="font-size: 24px; font-weight: 700;">To confirm someone's identity, you must live in the UK and:</span></p>
+<p>When a person applies for a UK passport, HM Passport Office sometimes needs to check that they are who they claim to be. <br><br>The person applying for the passport must ask someone they know well to confirm their identity.</p><p><span style="font-size: 24px; font-weight: 700;">To confirm someone's identity, you must live in the UK and:</span></p>
 
 <ul><li>have known the applicant personally for at least 2 years, for example as a friend or neighbour</li>
 <li>and work in or be retired from a <a href="/govuk">recognised profession</a></li>

--- a/views/guidance/confirming-your-identity.html
+++ b/views/guidance/confirming-your-identity.html
@@ -35,7 +35,7 @@ To confirm someone's identity, you need to:</p>
   <li>related to them</li>
   <li>in a relationship with them</li>
   <li>living at the same address</li>
-  <li>working for Her Majesty's Passport Office</li>
+  <li>working for HM Passport Office</li>
 </ul>
 
 <h2>How to confirm someone's identity online</h2>

--- a/views/guidance/who-can-confirm.html
+++ b/views/guidance/who-can-confirm.html
@@ -35,7 +35,7 @@ To confirm someone's identity, you need to:</p>
   <li>related to them</li>
   <li>in a relationship with them</li>
   <li>living at the same address</li>
-  <li>working for Her Majesty's Passport Office</li>
+  <li>working for HM Passport Office</li>
 </ul>
 
 <h2>How to confirm someone's identity online</h2>

--- a/views/priority-service/filter/passport-damaged.html
+++ b/views/priority-service/filter/passport-damaged.html
@@ -16,7 +16,7 @@
           <details>
               <summary><span class="summary">I'm not sure if my passport is damaged</span></summary>
               <div class="panel panel-border-narrow">
-                <p>Her Majesty's Passport Office classes your passport as damaged if:</p>
+                <p>HM Passport Office classes your passport as damaged if:</p>
                 <ul class="list-bullet">
                   <li>you can't read any of your details</li>
                   <li>the laminate cover has come away</li>

--- a/views/priority-service/overseas/passport-damaged.html
+++ b/views/priority-service/overseas/passport-damaged.html
@@ -16,7 +16,7 @@
           <details>
               <summary><span class="summary">I'm not sure if my passport is damaged</span></summary>
               <div class="panel panel-border-narrow">
-                <p>Her Majesty's Passport Office classes your passport as damaged if:</p>
+                <p>HM Passport Office classes your passport as damaged if:</p>
                 <ul class="list-bullet">
                   <li>you can't read any of your details</li>
                   <li>the laminate cover has come away</li>

--- a/views/production/filter/passport-damaged.html
+++ b/views/production/filter/passport-damaged.html
@@ -16,7 +16,7 @@
           <details>
               <summary><span class="summary">I'm not sure if my passport is damaged</span></summary>
               <div class="panel panel-border-narrow">
-                <p>Her Majesty's Passport Office classes your passport as damaged if:</p>
+                <p>HM Passport Office classes your passport as damaged if:</p>
                 <ul class="list-bullet">
                   <li>you can't read any of your details</li>
                   <li>the laminate cover has come away</li>

--- a/views/production/overseas/passport-damaged.html
+++ b/views/production/overseas/passport-damaged.html
@@ -16,7 +16,7 @@
           <details>
               <summary><span class="summary">I'm not sure if my passport is damaged</span></summary>
               <div class="panel panel-border-narrow">
-                <p>Her Majesty's Passport Office classes your passport as damaged if:</p>
+                <p>HM Passport Office classes your passport as damaged if:</p>
                 <ul class="list-bullet">
                   <li>you can't read any of your details</li>
                   <li>the laminate cover has come away</li>


### PR DESCRIPTION
Changed all instances of ‘Her Majesty’s Passport Office’ to ‘HM
Passport Office’