### PR TITLE
Mop up edits post csig review

### DIFF
--- a/views/csig/referee/applicant-summary.html
+++ b/views/csig/referee/applicant-summary.html
@@ -9,7 +9,7 @@
 {{/header}}
 {{$content}}
   {{#values.csig-child}}
-    <p>It looks like you're not eligible to do this for Suzanne Angela Smith. Please confirm your answers.</p>
+    <p>It looks like you're not eligible to do this for the applicant. Please confirm your answers.</p>
   {{/values.csig-child}}
   {{^values.csig-child}}
     <p>It looks like you're not eligible to do this for the applicant. Please confirm your answers.</p>

--- a/views/prototype/apply/confirmation.html
+++ b/views/prototype/apply/confirmation.html
@@ -25,7 +25,6 @@
           <p>Sign in to check who can do this and provide their details. You'll need your application reference: PEX 319 825 680X</p>
 
           <h2>2. Get your documents ready</h2>
-          <p>Sign into your application to check what you need to send.</p>
           <p>We can only receive your documents after your identity has been confirmed. We'll let you know when and where to send them.</p>
 
           <a href="/tracking/user" class="button">Sign in</a>
@@ -68,7 +67,7 @@
         <p>Sign in to check who can do this and provide their details. You'll need your application reference: PEX 319 825 680X</p>
 
         <h2>2. Get your documents ready</h2>
-        <p>Sign in  to check what you need to send. We can only receive your documents after your identity has been confirmed. We'll let you know when and where to send them.</p>
+        <p>We can only receive your documents after your identity has been confirmed. We'll let you know when and where to send them.</p>
 
         <a href="/tracking/user" class="button">Sign in</a>
       {% endif %}


### PR DESCRIPTION
- removed ‘Sign in to check what you need to send.’ from next steps
- changed dynamic name on check your answers to ‘for this applicant’