### PR TITLE
Confirm identity guidance

### DIFF
--- a/views/prototype/help/confirming-your-identity.html
+++ b/views/prototype/help/confirming-your-identity.html
@@ -11,7 +11,7 @@
 {{$content}}
 <aside class="part-navigation-container govuk" role="complementary">
   <nav role="navigation" class="grid-row part-navigation" aria-label="Pages in this guide">
-    <ul class="column-long">
+    <ul class="column-long font-xsmall">
         <li>
           &mdash; <a href="./who-can-confirm">Who can confirm someone's identity</a>
         </li>

--- a/views/prototype/help/confirming-your-identity.html
+++ b/views/prototype/help/confirming-your-identity.html
@@ -1,29 +1,32 @@
 {{< layout}}
 
-{{$pageTitle}}Confirming your identity{{/pageTitle}}
+{{$pageTitle}}Confirming someone's identity{{/pageTitle}}
 
 {{$propositionHeader}}{{/propositionHeader}}
 
 {{$header}}
-    <h1>How to confirm someone's identity</h1>
+    <h1>Confirming someone's identity</h1>
 {{/header}}
 
 {{$content}}
 <aside class="part-navigation-container govuk" role="complementary">
   <nav role="navigation" class="grid-row part-navigation" aria-label="Pages in this guide">
-    <ol class="column-half">
+    <ul class="column-long">
         <li>
-          <a href="./who-can-confirm">Who can confirm someone's identity</a>
+          &mdash; <a href="./who-can-confirm">Who can confirm someone's identity</a>
         </li>
         <li>
-          How to confirm someone's identity</a>
+          &mdash; How to confirm someone's identity</a>
         </li>
-    </ol>
+    </ul>
   </nav>
 </aside>
+
+<h2>How to confirm someone's identity</h2>
+
 <p>For applications with a digital photo, you can confirm someone's identity online. You don't need to sign a printed photo.</p>
 
-<h2>What the applicant needs to do</h2>
+<h3>What the applicant needs to do</h3>
 
   <p>As the applicant, you need to:</p>
   <ol class="list-number">
@@ -35,7 +38,7 @@
 
 <p>If you're applying for a child, the person you ask must be able to confirm where the child was born as well as their parents' names and years of birth.
 
-<h2>What the person confirming an identity needs to do</h2>
+<h3>What the person confirming an identity needs to do</h3>
 
 <p>As the person confirming someone's identity, you'll receive an email from HM Passport Office. The email includes a link and a reference to sign in online.</p>
 

--- a/views/prototype/help/who-can-confirm.html
+++ b/views/prototype/help/who-can-confirm.html
@@ -1,30 +1,31 @@
 {{< layout}}
 
-{{$pageTitle}}Confirming your identity{{/pageTitle}}
+{{$pageTitle}}Confirming someone's identity{{/pageTitle}}
 
 {{$propositionHeader}}{{/propositionHeader}}
 
 {{$header}}
-    <h1>Who can confirm someone's identity</h1>
+    <h1>Confirming someone's identity</h1>
 {{/header}}
 
 {{$content}}
 <aside class="part-navigation-container govuk" role="complementary">
   <nav role="navigation" class="grid-row part-navigation" aria-label="Pages in this guide">
-    <ol class="column-half">
+    <ul class="column-long">
         <li>
-          Who can confirm someone's identity
+          &mdash; Who can confirm someone's identity
         </li>
         <li>
-          <a href="./confirming-your-identity">How to confirm someone's identity</a>
+          &mdash; <a href="./confirming-your-identity">How to confirm someone's identity</a>
         </li>
-    </ol>
+    </ul>
   </nav>
 </aside>
+
+<h2>Who can confirm someone's identity</h2>
+
 <p>For some passport applications, HM Passport Office needs someone to confirm the applicant’s identity. This helps protect their identity and check the application belongs to the right person.
 </p>
-
-<h2>Who can do this</h2>
 
 To confirm someone's identity online, you need to:</p>
 <ul class="list-bullet">
@@ -37,7 +38,7 @@ To confirm someone's identity online, you need to:</p>
 
 <p>You must not be related, in a relationship with or living at the same address as the applicant or the person making the application. </p>
 
-<h2>Recognised professions</h2>
+<h3>Recognised professions</h3>
 
 <p>You must work in or be retired from a recognised profession and know the applicant personally.</p>
 
@@ -94,7 +95,7 @@ To confirm someone's identity online, you need to:</p>
 </ul>
 <div>
 
-<h2>Professions that are not accepted</h2>
+<h3>Professions that are not accepted</h3>
 
 <p>You cannot confirm someone's identity if you:<p>
 
@@ -103,10 +104,6 @@ To confirm someone's identity online, you need to:</p>
   <li>work for HM Passport Office</li>
   <li>work at UK Visas and Immigration and are involved with applications for British citizenship or right of abode in the UK</li>
 </ul>
-
-
-<h2><a href="./confirming-your-identity">Next</a></h2>
-
 
 {{/content}}
 

--- a/views/prototype/help/who-can-confirm.html
+++ b/views/prototype/help/who-can-confirm.html
@@ -11,7 +11,7 @@
 {{$content}}
 <aside class="part-navigation-container govuk" role="complementary">
   <nav role="navigation" class="grid-row part-navigation" aria-label="Pages in this guide">
-    <ul class="column-long">
+    <ul class="column-long font-xsmall">
         <li>
           &mdash; Who can confirm someone's identity
         </li>


### PR DESCRIPTION
Changes to the guidance for who can confirm identity and how to do it. Following the GOV.UK mainstream guide format more closely.