### PR TITLE
Tidying up lost and stolen content

### DIFF
--- a/static/emails/lost-stolen/ask-someone-to-confirm-your-identity.html
+++ b/static/emails/lost-stolen/ask-someone-to-confirm-your-identity.html
@@ -51,10 +51,15 @@ li {
                         <h2>What you need to do</h2>
                         <p>The person confirming your identity needs to complete the form and give it back to you. You can then send the form.</p>
 
+                        <p>Sign in to download the form:
+                         <br><a href="/csig/user?status=send-docs">https://www.passport.service.gov.uk/track</a></p>
+
+
                          <p>Use an envelope that is the right size for the form. You can use standard post or special delivery. You don't need to include a covering letter.</p>
                         <p>Send your form to:</p>
                         <p>HM Passport Office<br>
-                        Ref: PEX 896 345 1083<br>
+                        UK-DAP<br>
+                        PEX 896 345 1083<br>
                         Aragon Court<br>
                         Northminster Road<br>
                         Peterborough<br>

--- a/views/notifications.html
+++ b/views/notifications.html
@@ -88,7 +88,7 @@
   <h3>Lost stolen</h3>
   <ul>
     <li><a href="static/emails/lost-stolen/application-received.html">Application received</a></li>
-    <li><a href="static/emails/lost-stolen/ask-someone-to-confirm-your-identity.html">Ask someone to confirm your identity</a></li>
+    <li><a href="static/emails/lost-stolen/ask-someone-to-confirm-your-identity.html">Ask someone to confirm your identity (paper form, no documents)</a></li>
     <li><a href="static/emails/lost-stolen/confirming-your-identity.html">Confirming your identity</a></li>
     <li><a href="static/emails/lost-stolen/application-approved.html">Application approved</a></li>
     <li><a href="static/emails/lost-stolen/passport-on-its-way.html">Passport printed</a></li>

--- a/views/prototype/filter/summary.html
+++ b/views/prototype/filter/summary.html
@@ -39,7 +39,7 @@
     {% if not values['rising-16'] %}
       <p>It should take 3 weeks to get a new passport. Use the 1 week Fast Track service if you need to <a href="https://www.gov.uk/get-a-passport-urgently/1-week-fast-track-service">get a passport urgently</a>.</p>
     {% elif values['rising-16'] %}
-      <p>You'll get an adult passport because you're about to turn 16. It should take <br>3 weeks - you won't get it before your birthday.</p>
+      <p>As you're about to turn 16, you'll get an adult passport. It should take <br>3 weeks - you won't get it before your birthday.</p>
     {% endif %}
 
 

--- a/views/tracking/user/paper-application-confirmed-no-docs.html
+++ b/views/tracking/user/paper-application-confirmed-no-docs.html
@@ -25,7 +25,7 @@
         <ul class="list-bullet">
           <li>single sided</li>
           <li>on A4 or US letter sized paper</li>
-          <li>at its default size (sometimes called 'no scaling' or '100% scale')</li>
+          <li>at its default size (sometimes called &lsquo;no scaling&rsquo; or &lsquo;100% scale&rsquo;)</li>
           <li>in either black and white or colour</li>
         </ul>
        

--- a/views/tracking/user/paper-application-confirmed.html
+++ b/views/tracking/user/paper-application-confirmed.html
@@ -25,7 +25,7 @@
         <ul class="list-bullet">
           <li>single sided</li>
           <li>on A4 or US letter sized paper</li>
-          <li>at its default size (sometimes called 'no scaling' or '100% scale')</li>
+          <li>at its default size (sometimes called &lsquo;no scaling&rsquo; or &lsquo;100% scale&rsquo;)</li>
           <li>in either black and white or colour</li>
         </ul>
        
@@ -69,7 +69,7 @@
 
        <h3>2. Send the completed form and your documents</h3>
 
-       <p>Use a strong envelope that is the right size for your documents. You can use standard post or special delivery.</p>
+       <p>Use a strong envelope that is the right size for your documents. You can use standard post or special delivery. You do not need to include a covering letter.</p>
 
       <p>Send the form and your documents to:</p>
 


### PR DESCRIPTION
/ask-someone-to-confirm-your-identity.html

Added link to the tracking page.

/notifications

Made it clear which version of the 'ask someone to confirm identity' email we're linking to.

/summary

Reverted an earlier change to keep content consistent with other variants.

/paper-application-confirmed-no-docs.html

Replaced straight quotes with curly.

/paper-application-confirmed.html

Replaced straight quotes with curly. Added sentence telling the user not to send a covering letter.
